### PR TITLE
feat: allow symfony 6 and add compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,14 @@
   "license": "MIT",
   "require": {
     "php": "^7.4|8.*",
-    "symfony/framework-bundle": "^5.2",
-    "symfony/messenger": "^v5.3.0",
+    "symfony/framework-bundle": "^5.4||^6.0",
+    "symfony/messenger": "^5.4||^6.0",
     "flix-tech/avro-serde-php": "^2.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.0",
     "phpstan/phpstan": "^0.12.52",
-    "symfony/phpunit-bridge": "^5.3",
+    "symfony/phpunit-bridge": "^5.4||^6.0",
     "matthiasnoback/symfony-config-test": "^4.2"
   },
   "suggest": {

--- a/src/DependencyInjection/AvroRegyExtension.php
+++ b/src/DependencyInjection/AvroRegyExtension.php
@@ -33,7 +33,7 @@ class AvroRegyExtension extends Extension
         }
     }
 
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'avro_regy';
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,7 +9,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('avro_regy');
 

--- a/tests/ServiceWiringTest.php
+++ b/tests/ServiceWiringTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class ServiceWiringTest extends TestCase
 {
-    public function testServiceWiring()
+    public function testServiceWiring(): void
     {
         $kernel = new AvroRegyTestingKernel([
             'base_uri' => 'http://localhost',
@@ -48,14 +48,14 @@ class AvroRegyTestingKernel extends Kernel
         parent::__construct('test', true);
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [
             new AvroRegyBundle(),
         ];
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(function(ContainerBuilder $builder) {
             $builder->register('example_serializer', ExampleSerializer::class)
@@ -73,7 +73,7 @@ class AvroRegyTestingKernel extends Kernel
         });
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return __DIR__.'/cache/'.spl_object_hash($this);
     }


### PR DESCRIPTION
Allow SF 6 in composer.json and add needed return types. I also bumped lowest SF version to 5.4 since >5.4 is out of life.